### PR TITLE
chore: separate publish workflow into 2 workflows, build and publish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: Build project with core-bundle
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "Set the branch to use for release"
+        type: string
+        required: false
+        default: "main"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: yarn
+      - name: Retrieve Scripts
+        run: |
+          git clone https://github.com/forcedotcom/bundle-publish-scripts.git
+      - name: Update for core bundle
+        run: |
+          node bundle-publish-scripts/scripts/updateForCoreBundle.js
+      - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
+      - name: Build the Project
+        run: |
+          yarn build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,14 @@
+name: Publish
+on:
+  workflow_call:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish a Package
+        run: |
+          npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN --verbose
+          npm publish --verbose
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/releaseWithCoreBundle.yml
+++ b/.github/workflows/releaseWithCoreBundle.yml
@@ -1,37 +1,19 @@
-name: publish project with core-bundle
+name: Publish project with core-bundle
 on:
   workflow_call:
     inputs:
       branch:
-        description: 'Set the branch to use for release'
+        description: "Set the branch to use for release"
         type: string
         required: false
-        default: 'main'
+        default: "main"
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: lts/*
-          cache: yarn
-      - name: Retrieve Scripts
-        run: |
-          git clone https://github.com/forcedotcom/bundle-publish-scripts.git
-      - name: Update for Publishing
-        run: |
-          node bundle-publish-scripts/scripts/updateForCoreBundle.js
-      - uses: salesforcecli/github-workflows/.github/actions/yarnInstallWithRetries@main
-      - name: Build the Project
-        run: |
-          yarn build
-      - name: Publish a Package
-        run: |
-          npm config set //registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN --verbose
-          npm publish --verbose
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    name: Call build workflow
+    uses: ./.github/workflows/build.yml
+    with:
+      branch: ${{ inputs.branch }}
+  publish:
+    name: Call publish workflow
+    uses: ./.github/workflows/publish.yml


### PR DESCRIPTION
Separate publishing workflow into 2 different workflows: build and publish, so they can be reused

@W-15634776@